### PR TITLE
タップゾーンの割合を表示と一致させる

### DIFF
--- a/apps/death-tap-counter/src/components/DeathTapCounter.tsx
+++ b/apps/death-tap-counter/src/components/DeathTapCounter.tsx
@@ -169,7 +169,7 @@ export const DeathTapCounter = () => {
         role="button"
         tabIndex={0}
       >
-        {/* 上部エリア（20% - カウント減少ゾーン） */}
+        {/* 上部エリア（10% - カウント減少ゾーン） */}
         <div
           className={`absolute top-0 left-0 w-full h-[10%] flex items-center justify-center bg-gradient-to-b from-red-900/20 to-red-800/10 border-b border-red-600/30 transition-all duration-150 ${
             isFlashing ? 'bg-white/10' : ''
@@ -178,7 +178,7 @@ export const DeathTapCounter = () => {
           <div className="text-xl sm:text-2xl text-red-400 font-medium">タップで -1</div>
         </div>
 
-        {/* 下部エリア（80% - カウント増加ゾーン） */}
+        {/* 下部エリア（90% - カウント増加ゾーン） */}
         <div
           className={`absolute bottom-0 left-0 w-full h-[90%] flex flex-col items-center justify-center bg-gradient-to-b from-green-800/10 to-green-900/20 transition-all duration-150 ${
             isFlashing ? 'bg-white/10' : ''

--- a/apps/death-tap-counter/src/types/config.ts
+++ b/apps/death-tap-counter/src/types/config.ts
@@ -4,7 +4,7 @@
 
 // アプリケーション設定の型
 export interface AppConfig {
-  readonly ZONE_RATIO: number // 2:8の比率 (0.2)
+  readonly ZONE_RATIO: number // 1:9の比率 (0.1)
   readonly MAX_HISTORY: number // 最大履歴件数 (10000)
   readonly SWIPE_THRESHOLD: {
     readonly DISTANCE: number // 80px
@@ -18,7 +18,7 @@ export interface AppConfig {
 
 // アプリケーション設定値
 export const APP_CONFIG: AppConfig = {
-  ZONE_RATIO: 0.2,
+  ZONE_RATIO: 0.1,
   MAX_HISTORY: 10000,
   SWIPE_THRESHOLD: {
     DISTANCE: 80,

--- a/apps/death-tap-counter/src/utils/__tests__/zone.test.ts
+++ b/apps/death-tap-counter/src/utils/__tests__/zone.test.ts
@@ -8,20 +8,20 @@ describe('zone utilities', () => {
   describe('getTapZone', () => {
     const screenHeight = 1000
 
-    test('上部20%の領域では decrement を返す', () => {
+    test('上部10%の領域では decrement を返す', () => {
       // 上端
       expect(getTapZone({ x: 100, y: 0 }, screenHeight)).toBe('decrement')
 
-      // 20%境界線付近（上部側）
-      expect(getTapZone({ x: 100, y: 199 }, screenHeight)).toBe('decrement')
+      // 10%境界線付近（上部側）
+      expect(getTapZone({ x: 100, y: 99 }, screenHeight)).toBe('decrement')
 
-      // 20%境界線ちょうど
-      expect(getTapZone({ x: 100, y: 200 }, screenHeight)).toBe('decrement')
+      // 10%境界線ちょうど
+      expect(getTapZone({ x: 100, y: 100 }, screenHeight)).toBe('decrement')
     })
 
-    test('下部80%の領域では increment を返す', () => {
-      // 20%境界線を超えた位置
-      expect(getTapZone({ x: 100, y: 201 }, screenHeight)).toBe('increment')
+    test('下部90%の領域では increment を返す', () => {
+      // 10%境界線を超えた位置
+      expect(getTapZone({ x: 100, y: 101 }, screenHeight)).toBe('increment')
 
       // 下部中央
       expect(getTapZone({ x: 100, y: 600 }, screenHeight)).toBe('increment')
@@ -30,17 +30,17 @@ describe('zone utilities', () => {
       expect(getTapZone({ x: 100, y: 999 }, screenHeight)).toBe('increment')
     })
 
-    test('異なる画面高さでも正しく2:8の比率で判定する', () => {
+    test('異なる画面高さでも正しく1:9の比率で判定する', () => {
       const smallScreen = 500
       const largeScreen = 2000
 
-      // 小さな画面での20%境界
-      expect(getTapZone({ x: 100, y: 100 }, smallScreen)).toBe('decrement')
-      expect(getTapZone({ x: 100, y: 101 }, smallScreen)).toBe('increment')
+      // 小さな画面での10%境界
+      expect(getTapZone({ x: 100, y: 50 }, smallScreen)).toBe('decrement')
+      expect(getTapZone({ x: 100, y: 51 }, smallScreen)).toBe('increment')
 
-      // 大きな画面での20%境界
-      expect(getTapZone({ x: 100, y: 400 }, largeScreen)).toBe('decrement')
-      expect(getTapZone({ x: 100, y: 401 }, largeScreen)).toBe('increment')
+      // 大きな画面での10%境界
+      expect(getTapZone({ x: 100, y: 200 }, largeScreen)).toBe('decrement')
+      expect(getTapZone({ x: 100, y: 201 }, largeScreen)).toBe('increment')
     })
   })
 

--- a/apps/death-tap-counter/src/utils/zone.ts
+++ b/apps/death-tap-counter/src/utils/zone.ts
@@ -9,7 +9,7 @@ import { APP_CONFIG } from '@/types/config'
  * 座標からタップゾーンを判定する
  * @param point - タップされた座標
  * @param screenHeight - 画面の高さ
- * @returns タップゾーン（decrement: 上20%, increment: 下80%）
+ * @returns タップゾーン（decrement: 上10%, increment: 下90%）
  */
 export const getTapZone = (point: Point, screenHeight: number): TapZone => {
   const zoneThreshold = screenHeight * APP_CONFIG.ZONE_RATIO


### PR DESCRIPTION
## Summary
- タップ判定の閾値を見た目の10%/90%に合わせてZONE_RATIOを更新
- 関連するコメントとタップゾーン判定テストを新しい比率に合わせて調整

## Testing
- npm test
- npm run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a8f060f0832bb6f54303ac62189e)